### PR TITLE
Dynamically find the py4j version

### DIFF
--- a/python/spark_esri/__init__.py
+++ b/python/spark_esri/__init__.py
@@ -7,6 +7,7 @@ import sys
 from typing import Dict
 
 import arcpy
+import glob
 
 pro_home = arcpy.GetInstallInfo()["InstallDir"]
 pro_lib_dir = os.path.join(pro_home, "Java", "lib")
@@ -15,7 +16,8 @@ spark_home = os.path.join(pro_runtime_dir, "spark")
 
 # add spark/py4j libraries from Pro runtime to path for import
 sys.path.insert(0, os.path.join(spark_home, "python", "lib", "pyspark.zip"))
-sys.path.insert(0, os.path.join(spark_home, "python", "lib", "py4j-0.10.7-src.zip"))
+py4j_zip = glob.glob(os.path.join(spark_home, "python", "lib", "py4j-*-src.zip"))[0]
+sys.path.insert(0, py4j_zip)
 
 from pyspark import SparkContext, SparkConf
 from pyspark.sql import SparkSession


### PR DESCRIPTION
py4j version number changed in Pro 2.8. In order to support both Pro 2.6 and 2.8, need to dynamically find the proper py4j zip file. Otherwise import spark_esri fails because py4j could not be found.