### PR TITLE
os.unsetenv so works with Pro 3.0.*

### DIFF
--- a/python/spark_esri/__init__.py
+++ b/python/spark_esri/__init__.py
@@ -69,8 +69,8 @@ def spark_start(config: Dict = {}) -> SparkSession:
     _set_pyspark_python()
     #
     # these need to be reset on every run or pyspark will think the Java gateway is still up and running
-    os.environ.unsetenv("PYSPARK_GATEWAY_PORT")
-    os.environ.unsetenv("PYSPARK_GATEWAY_SECRET")
+    os.unsetenv("PYSPARK_GATEWAY_PORT")
+    os.unsetenv("PYSPARK_GATEWAY_SECRET")
     SparkContext._jvm = None
     SparkContext._gateway = None
 


### PR DESCRIPTION
Ran into an issue running with Pro 3.0.3 with `os.environ.unsetenv` being deprecated in lieu of `os.unsetenv`. I checked if this is backward compatible back to Python 3.7, and it is, so I modified it. This works with Pro 3.0.3. 